### PR TITLE
Fix web repository owner and fork filtering

### DIFF
--- a/github_linter/__init__.py
+++ b/github_linter/__init__.py
@@ -241,18 +241,18 @@ def get_all_user_repos(github: GithubLinter, config: dict[str, Any] | None = Non
 
     if config["linter"].get("owner_list", []):
         repolist = []
+        repo_filter = config["linter"].get("repo_filter")
+        check_forks = config["linter"].get("check_forks", False)
 
         for owner in config["linter"]["owner_list"]:
             logger.debug("Pulling all the repositories for {}", owner)
-            if config.get("linter", {}).get("repo_filter") is not None:
-                for repo in github.github3.repositories_by(username=owner, type="owner"):
-                    if repo.name in config["linter"]["repo_filter"]:
-                        repolist.append(repo.full_name)
-            else:
-                repolist.extend([repo.full_name for repo in github.github3.repositories(owner)])
+            for repo in github.github3.repositories_by(username=owner, type="owner"):
+                if (repo_filter is None or repo.name in repo_filter) and (check_forks or not repo.fork):
+                    repolist.append(repo.full_name)
     else:
         logger.debug("Pulling all the repositories I own")
-        repolist = [repo.full_name for repo in github.github3.repositories(type="owner")]
+        check_forks = config["linter"].get("check_forks", False)
+        repolist = [repo.full_name for repo in github.github3.repositories(type="owner") if check_forks or not repo.fork]
     logger.debug("Repo list: {}", ", ".join(repolist))
     return repolist
 

--- a/github_linter/web/__init__.py
+++ b/github_linter/web/__init__.py
@@ -435,7 +435,7 @@ def get_repos_query(config: dict[str, Any] | None = None) -> Any:
 
     owner_list = linter_config.get("owner_list", [])
     if owner_list:
-        stmt = stmt.where(SQLRepos.owner.in_(owner_list))
+        stmt = stmt.where(sqlalchemy.func.lower(SQLRepos.owner).in_([owner.lower() for owner in owner_list]))
     if not linter_config.get("check_forks", False):
         stmt = stmt.where(SQLRepos.fork.is_(False))
     return stmt

--- a/github_linter/web/__init__.py
+++ b/github_linter/web/__init__.py
@@ -28,6 +28,7 @@ __all__ = [
 ]
 
 from .. import GithubLinter, get_all_user_repos
+from ..utils import load_config
 
 DB_PATH = Path("~/.config/github_linter.sqlite").expanduser().resolve()
 DB_URL = f"sqlite+aiosqlite:///{DB_PATH.as_posix()}"
@@ -172,7 +173,7 @@ async def update_stored_repo(repo: Repository) -> None:
             {
                 "full_name": repo.full_name,
                 "name": repo.name,
-                "owner": repo.owner.name,
+                "owner": repo.owner.login,
                 "organization": repo.organization.name if repo.organization else None,
                 "default_branch": repo.default_branch,
                 "archived": repo.archived,
@@ -209,7 +210,7 @@ async def update_stored_repos() -> None:
     async with engine.begin() as conn:
         await conn.run_sync(base.metadata.create_all)
 
-        github_repos = get_all_user_repos(githublinter)
+        github_repos = get_all_user_repos(githublinter, githublinter.config)
 
         logger.info(f"Got {len(github_repos)} repos")
         for repo in github_repos:
@@ -415,13 +416,29 @@ async def get_repos(session: Annotated[AsyncSession, Depends(get_async_session)]
     """endpoint to provide the cached repo list"""
 
     try:
-        stmt = sqlalchemy.select(SQLRepos)
+        stmt = get_repos_query()
         result = await session.execute(stmt)
         retval = [RepoDataSimple.model_validate(element.SQLRepos) for element in result.fetchall()]
     except OperationalError as operational_error:
         logger.warning("Failed to pull repos from DB: {}", operational_error)
         return []
     return retval
+
+
+def get_repos_query(config: dict[str, Any] | None = None) -> Any:
+    """Build the cached repository query constrained by the linter configuration."""
+    if config is None:
+        config = load_config()
+
+    linter_config = config.get("linter", {})
+    stmt = sqlalchemy.select(SQLRepos)
+
+    owner_list = linter_config.get("owner_list", [])
+    if owner_list:
+        stmt = stmt.where(SQLRepos.owner.in_(owner_list))
+    if not linter_config.get("check_forks", False):
+        stmt = stmt.where(SQLRepos.fork.is_(False))
+    return stmt
 
 
 @app.get("/", response_model=None)

--- a/tests/test_github_data.py
+++ b/tests/test_github_data.py
@@ -4,6 +4,39 @@ from github_linter import GithubLinter
 from github_linter.web import get_all_user_repos
 
 
+class StubRepo:
+    """Minimal GitHub repository response for owner-filter tests."""
+
+    def __init__(self, full_name: str, fork: bool = False) -> None:
+        self.full_name = full_name
+        self.name = full_name.rsplit("/", maxsplit=1)[1]
+        self.fork = fork
+
+
+class StubGithub3:
+    """Records the repository listing arguments used by the linter."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
+
+    def repositories_by(self, username: str, type: str) -> list[StubRepo]:
+        self.calls.append((username, type))
+        return [StubRepo(f"{username}/repository"), StubRepo(f"{username}/fork", fork=True)]
+
+
+def test_get_all_user_repos_scopes_each_request_to_configured_owner() -> None:
+    """Configured owners must be sent as usernames, never as a repository type."""
+    github3 = StubGithub3()
+    linter = object.__new__(GithubLinter)
+    linter.github3 = github3
+    config = {"linter": {"owner_list": ["yaleman", "terminaloutcomes"]}}
+
+    result = get_all_user_repos(linter, config)
+
+    assert result == ["yaleman/repository", "terminaloutcomes/repository"]
+    assert github3.calls == [("yaleman", "owner"), ("terminaloutcomes", "owner")]
+
+
 @pytest.mark.network
 def test_get_all_user_repos() -> None:
     """tests what we get back from it, can be slow and burn things"""

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -28,5 +28,5 @@ def test_repo_query_respects_linter_config() -> None:
 
     compiled = str(query.compile(dialect=sqlite.dialect(), compile_kwargs={"literal_binds": True}))
 
-    assert "repos.owner IN ('yaleman', 'terminaloutcomes')" in compiled
+    assert "lower(repos.owner) IN ('yaleman', 'terminaloutcomes')" in compiled
     assert "repos.fork IS 0" in compiled

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,8 +1,9 @@
 """test the web interface a bit"""
 
 from fastapi.testclient import TestClient
+from sqlalchemy.dialects import sqlite
 
-from github_linter.web import app
+from github_linter.web import app, get_repos_query
 
 client = TestClient(app)
 
@@ -12,3 +13,20 @@ def test_read_main() -> None:
     response = client.get("/")
     assert response.status_code == 200
     assert b"<title>Github Linter</title>" in response.content
+
+
+def test_repo_query_respects_linter_config() -> None:
+    """The cached web view must not expose repos outside configured owners or forks."""
+    query = get_repos_query(
+        {
+            "linter": {
+                "owner_list": ["yaleman", "terminaloutcomes"],
+                "check_forks": False,
+            }
+        }
+    )
+
+    compiled = str(query.compile(dialect=sqlite.dialect(), compile_kwargs={"literal_binds": True}))
+
+    assert "repos.owner IN ('yaleman', 'terminaloutcomes')" in compiled
+    assert "repos.fork IS 0" in compiled


### PR DESCRIPTION
## Summary

- Scope GitHub repository discovery to configured owners.
- Exclude forked repositories unless `check_forks` is enabled.
- Apply owner and fork filters to the web repository query.
- Correct cached repository owner handling and add regression coverage.

## Testing

- Added unit tests for owner-scoped repository discovery and configured web queries.